### PR TITLE
Documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+2
+
+* Update README to include basic documentation
+* Update pubspec.yaml description
+
 ## 0.1.0+1
 
 * Fix author email.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: qr
 version: 0.1.0+1
 author: Kevin Moore <github@j832.com>
-description: A demo of generating QR codes in Dart.
+description: A library for generating QR codes in Dart.
 homepage: https://github.com/kevmoo/qr.dart/
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: qr
-version: 0.1.0+1
+version: 0.1.0+2
 author: Kevin Moore <github@j832.com>
 description: A library for generating QR codes in Dart.
 homepage: https://github.com/kevmoo/qr.dart/

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-*QR - Dart* is a QR code generation library written in Dart.
+**QR - Dart** is a QR code generation library written in Dart.
 
 [![Build Status](https://travis-ci.org/kevmoo/qr.dart.svg?branch=master)](https://travis-ci.org/kevmoo/qr.dart)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-qr.dart is a QR code generation library written in Dart.
+*QR - Dart* is a QR code generation library written in Dart.
 
 [![Build Status](https://travis-ci.org/kevmoo/qr.dart.svg?branch=master)](https://travis-ci.org/kevmoo/qr.dart)
 
@@ -38,11 +38,11 @@ Now you can use your `_qrCode` instance to render a graphical representation of 
 
 ```dart
 for (int x = 0; x < _qrCode.moduleCount; x++) {
-	for (int y = 0; y < _qrCode.moduleCount; y++) {
-		if (_qrCode.isDark(y, x)) {
-			// render a dark square on the canvas
-		}
-	}
+  for (int y = 0; y < _qrCode.moduleCount; y++) {
+    if (_qrCode.isDark(y, x)) {
+      // render a dark square on the canvas
+    }
+  }
 }
 ```
 
@@ -52,7 +52,7 @@ See the `example` directory for further details.
 
 The following libraries use qr.dart to generate QR codes for you out of the box:
 
-[qr.flutter](https://github.com/lukef/qr.flutter) - A Flutter Widget to render QR codes
+[QR - Flutter](https://github.com/lukef/qr.flutter) - A Flutter Widget to render QR codes
 
 # Demo
 

--- a/readme.md
+++ b/readme.md
@@ -29,17 +29,17 @@ import 'package:qr/qr.dart';
 To build your QR code data you should do so as such:
 
 ```dart
-final _qrCode = new QrCode(4, QrErrorCorrectLevel.L);
-_qrCode.addData("Hello, world in QR form!");
-_qrCode.make();
+final qrCode = new QrCode(4, QrErrorCorrectLevel.L);
+qrCode.addData("Hello, world in QR form!");
+qrCode.make();
 ```
 
 Now you can use your `_qrCode` instance to render a graphical representation of the QR code. A basic implementation would be as such:
 
 ```dart
-for (int x = 0; x < _qrCode.moduleCount; x++) {
-  for (int y = 0; y < _qrCode.moduleCount; y++) {
-    if (_qrCode.isDark(y, x)) {
+for (int x = 0; x < qrCode.moduleCount; x++) {
+  for (int y = 0; y < qrCode.moduleCount; y++) {
+    if (qrCode.isDark(y, x)) {
       // render a dark square on the canvas
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,63 @@
+qr.dart is a QR code generation library written in Dart.
+
 [![Build Status](https://travis-ci.org/kevmoo/qr.dart.svg?branch=master)](https://travis-ci.org/kevmoo/qr.dart)
 
-## Dart QR code generation library.
+# Features
 
-Demo: https://kevmoo.github.io/qr.dart/
+- Supports QR code versions 1 - 40
+- Error correction / redundancy
+
+# Installing
+
+You can install the package by adding the following lines to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  qr: "^0.1.0+1"
+```
+
+After adding the dependency to your `pubspec.yaml` you can run: `pub get` or `flutter packages get` if you're using Flutter.
+
+# Getting started
+
+To start, import the dependency in your code:
+
+```dart
+import 'package:qr/qr.dart';
+```
+
+Next, define your QR code data you should do so as such:
+
+```dart
+final _qrCode = new QrCode(4, QrErrorCorrectLevel.L);
+_qrCode.addData("Hello, world in QR form!");
+_qrCode.make();
+```
+
+Now you can use your `_qrCode` instance to render a graphical representation of the QR code. A basic implementation would be as such:
+
+```dart
+for (int x = 0; x < _qrCode.moduleCount; x++) {
+	for (int y = 0; y < _qrCode.moduleCount; y++) {
+		if (_qrCode.isDark(y, x)) {
+			// render a dark square on the canvas
+		}
+	}
+}
+```
+
+See the `example` directory for further details.
+
+# Pre-made UI libraries
+
+The following libraries use qr.dart to generate QR codes for you out of the box:
+
+[qr.flutter](https://github.com/lukef/qr.flutter) - A Flutter Widget to render QR codes
+
+# Demo
+
+A working demo can be found here: [https://kevmoo.github.io/qr.dart/](https://kevmoo.github.io/qr.dart/)
+
 
 # Authors
  * [Kevin Moore](https://github.com/kevmoo) ([@kevmoo](http://twitter.com/kevmoo))

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ To start, import the dependency in your code:
 import 'package:qr/qr.dart';
 ```
 
-Next, define your QR code data you should do so as such:
+To build your QR code data you should do so as such:
 
 ```dart
 final _qrCode = new QrCode(4, QrErrorCorrectLevel.L);


### PR DESCRIPTION
- updated README
- updated pubspec description

I'm not sure, based on the new pub site, whether README files for Dart libraries should include installation instructions, etc because pub provides these directly. If they're redundant, and that's the best practice, then I can remove them super quickly.

I added a shameless plug for the Flutter thing I made also.