### PR TITLE
fix: throw  type 'double' is not a subtype of type 'int'  error

### DIFF
--- a/lib/src/qr_code.dart
+++ b/lib/src/qr_code.dart
@@ -75,7 +75,7 @@ class QrCode {
       var lostPoint = qr_util.getLostPoint(this);
 
       if (i == 0 || minLostPoint > lostPoint) {
-        minLostPoint = lostPoint;
+        minLostPoint = lostPoint.toInt();
         pattern = i;
       }
     }


### PR DESCRIPTION
Throw ` type 'double' is not a subtype of type 'int' ` error.
platform version
```
• Flutter version 0.2.11-pre.23 at /Users/andy/flutter
    • Framework revision a2951a9a1f (7 hours ago), 2018-04-10 18:12:34 -0700
    • Engine revision ed303c628f
    • Dart version 2.0.0-dev.47.0.flutter-23ae4fa098
```