### PR TITLE
Export the InputTooLongException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .dart_tool
 .pub
 pubspec.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .dart_tool
 .pub
 pubspec.lock
-.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2
+
+- Expose `InputTooLongException` exception so that applications and libraries can check for data length errors.
+
 ## 1.1.1
 
 - Require Dart SDK `>=2.1.0 <3.0.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2
+## 1.2.0
 
 - Expose `InputTooLongException` exception so that applications and libraries can check for data length errors.
 

--- a/lib/qr.dart
+++ b/lib/qr.dart
@@ -1,3 +1,4 @@
 export 'src/bit_buffer.dart';
 export 'src/error_correct_level.dart';
+export 'src/input_too_long_exception.dart';
 export 'src/qr_code.dart' hide qrModules;


### PR DESCRIPTION
It's not possible to check for `InputTooLongException` because it isn't exported.