### PR TITLE
Support newer meta versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: '>=2.13.3 <3.0.0'
 
 dependencies:
-  meta: ^1.3.0
+  meta:  '>=1.3.0  <=1.7.0'
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
This resolves my problem from #57 without failing any test. There shouldn't be any problems since it's not a major release of meta.