### PR TITLE
feat: Throw InputTooLongException for data exceeding QR version 40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 - `QrCode.fromData` now intelligently picks the right mode.
 - Require `sdk: ^3.8.0`.
-- Throws InputTooLongException for data that exceeds QR code version 40 capacity, preventing the generation of invalid QR codes.
+- Throws `InputTooLongException` for data that exceeds QR code version 40 capacity,
+  preventing the generation of invalid QR codes.
 
 ## 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `QrCode.fromData` now intelligently picks the right mode.
 - Require `sdk: ^3.8.0`.
+- Throws InputTooLongException for data that exceeds QR code version 40 capacity, preventing the generation of invalid QR codes.
 
 ## 3.0.2
 

--- a/lib/src/qr_code.dart
+++ b/lib/src/qr_code.dart
@@ -64,36 +64,39 @@ class QrCode {
       .._addToList(QrByte.fromUint8List(data));
   }
 
-  static int _calculateTypeNumberFromData(int errorCorrectLevel, QrDatum data) {
-    int typeNumber;
-    for (typeNumber = 1; typeNumber <= 40; typeNumber++) {
-      final rsBlocks = QrRsBlock.getRSBlocks(typeNumber, errorCorrectLevel);
+  static int _calculateTotalDataBits(int typeNumber, int errorCorrectLevel) {
+    final rsBlocks = QrRsBlock.getRSBlocks(typeNumber, errorCorrectLevel);
+    var totalDataBits = 0;
+    for (var rsBlock in rsBlocks) {
+      totalDataBits += rsBlock.dataCount * 8;
+    }
+    return totalDataBits;
+  }
 
-      var totalDataCount = 0;
-      for (var i = 0; i < rsBlocks.length; i++) {
-        totalDataCount += rsBlocks[i].dataCount;
-      }
+  static int _calculateTypeNumberFromData(int errorCorrectLevel, QrDatum data) {
+    for (var typeNumber = 1; typeNumber <= 40; typeNumber++) {
+      final totalDataBits = _calculateTotalDataBits(
+        typeNumber,
+        errorCorrectLevel,
+      );
 
       final buffer = QrBitBuffer()
         ..put(data.mode, 4)
         ..put(data.length, _lengthInBits(data.mode, typeNumber));
       data.write(buffer);
-      if (buffer.length <= totalDataCount * 8) return typeNumber;
+
+      if (buffer.length <= totalDataBits) return typeNumber;
     }
 
     // If we reach here, the data is too long for any QR Code version.
-    final lastVersionRsBlocks = QrRsBlock.getRSBlocks(40, errorCorrectLevel);
-    var lastVersionTotalBits = 0;
-    for (var rsBlock in lastVersionRsBlocks) {
-      lastVersionTotalBits += rsBlock.dataCount * 8;
-    }
-
     final buffer = QrBitBuffer()
       ..put(data.mode, 4)
       ..put(data.length, _lengthInBits(data.mode, 40));
     data.write(buffer);
 
-    throw InputTooLongException(buffer.length, lastVersionTotalBits);
+    final maxBits = _calculateTotalDataBits(40, errorCorrectLevel);
+
+    throw InputTooLongException(buffer.length, maxBits);
   }
 
   void addData(String data) => _addToList(QrByte(data));
@@ -142,19 +145,14 @@ List<int> _createData(
 
   // HUH?
   // ç≈ëÂÉfÅ[É^êîÇåvéZ
-  var totalDataCount = 0;
-  for (var i = 0; i < rsBlocks.length; i++) {
-    totalDataCount += rsBlocks[i].dataCount;
-  }
-
-  final totalByteCount = totalDataCount * 8;
-  if (buffer.length > totalByteCount) {
-    throw InputTooLongException(buffer.length, totalByteCount);
-  }
+  final totalDataBits = QrCode._calculateTotalDataBits(
+    typeNumber,
+    errorCorrectLevel,
+  );
 
   // HUH?
   // èIí[ÉRÅ[Éh
-  if (buffer.length + 4 <= totalByteCount) {
+  if (buffer.length + 4 <= totalDataBits) {
     buffer.put(0, 4);
   }
 
@@ -164,7 +162,7 @@ List<int> _createData(
   }
 
   // padding
-  final bitDataCount = totalDataCount * 8;
+  final bitDataCount = totalDataBits;
   var count = 0;
   for (;;) {
     if (buffer.length >= bitDataCount) {

--- a/test/qr_code_test.dart
+++ b/test/qr_code_test.dart
@@ -137,43 +137,31 @@ void main() {
   });
 
   group('_calculateTypeNumberFromData - Version 40 Boundary Handling', () {
-    test(
-      '''
-      should generate a QrCode with version 40
-      for data slightly exceeding version 39 capacity
-      ''',
-      () {
-        // 2952 bytes exceeds v39 (L) capacity of 2951.
-        final largeData = '|' * 2952;
+    test('generate v40 for data exceeding v39 capacity', () {
+      // 2952 bytes exceeds v39 (L) capacity of 2951.
+      final largeData = '|' * 2952;
 
-        final qrCode = QrCode.fromData(
-          data: largeData,
+      final qrCode = QrCode.fromData(
+        data: largeData,
+        errorCorrectLevel: QrErrorCorrectLevel.L,
+      );
+
+      expect(qrCode.typeNumber, 40);
+    });
+
+    test('throw InputTooLongException for data exceeding v40 capacity', () {
+      // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
+      final excessivelyLargeData = '|' * 2954;
+
+      // An exception should be thrown for data exceeding the capacity
+      expect(
+        () => QrCode.fromData(
+          data: excessivelyLargeData,
           errorCorrectLevel: QrErrorCorrectLevel.L,
-        );
-
-        expect(qrCode.typeNumber, 40);
-      },
-    );
-
-    test(
-      '''
-      should throw InputTooLongException 
-      for data exceeding version 40 capacity
-      ''',
-      () {
-        // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
-        final excessivelyLargeData = '|' * 2954;
-
-        // An exception should be thrown for data exceeding the capacity
-        expect(
-          () => QrCode.fromData(
-            data: excessivelyLargeData,
-            errorCorrectLevel: QrErrorCorrectLevel.L,
-          ),
-          throwsA(isA<InputTooLongException>()),
-        );
-      },
-    );
+        ),
+        throwsA(isA<InputTooLongException>()),
+      );
+    });
   });
 }
 

--- a/test/qr_code_test.dart
+++ b/test/qr_code_test.dart
@@ -3,9 +3,6 @@
 import 'dart:typed_data';
 
 import 'package:qr/qr.dart';
-import 'package:qr/src/error_correct_level.dart';
-import 'package:qr/src/qr_code.dart';
-import 'package:qr/src/qr_image.dart';
 import 'package:test/test.dart';
 
 import 'qr_code_test_data.dart';
@@ -140,37 +137,43 @@ void main() {
   });
 
   group('_calculateTypeNumberFromData - Version 40 Boundary Handling', () {
-    test('''
+    test(
+      '''
       should generate a QrCode with version 40
       for data slightly exceeding version 39 capacity
-      ''', () {
-      // 2952 bytes exceeds v39 (L) capacity of 2951.
-      final largeData = '|' * 2952;
+      ''',
+      () {
+        // 2952 bytes exceeds v39 (L) capacity of 2951.
+        final largeData = '|' * 2952;
 
-      final qrCode = QrCode.fromData(
-        data: largeData,
-        errorCorrectLevel: QrErrorCorrectLevel.L,
-      );
+        final qrCode = QrCode.fromData(
+          data: largeData,
+          errorCorrectLevel: QrErrorCorrectLevel.L,
+        );
 
-      expect(qrCode.typeNumber, 40);
-    });
+        expect(qrCode.typeNumber, 40);
+      },
+    );
 
-    test('''
+    test(
+      '''
       should throw InputTooLongException 
       for data exceeding version 40 capacity
-      ''', () {
-      // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
-      final excessivelyLargeData = '|' * 2954;
+      ''',
+      () {
+        // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
+        final excessivelyLargeData = '|' * 2954;
 
-      // An exception should be thrown for data exceeding the capacity
-      expect(
-        () => QrCode.fromData(
-          data: excessivelyLargeData,
-          errorCorrectLevel: QrErrorCorrectLevel.L,
-        ),
-        throwsA(isA<InputTooLongException>()),
-      );
-    });
+        // An exception should be thrown for data exceeding the capacity
+        expect(
+          () => QrCode.fromData(
+            data: excessivelyLargeData,
+            errorCorrectLevel: QrErrorCorrectLevel.L,
+          ),
+          throwsA(isA<InputTooLongException>()),
+        );
+      },
+    );
   });
 }
 

--- a/test/qr_code_test.dart
+++ b/test/qr_code_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:typed_data';
 
+import 'package:qr/qr.dart';
 import 'package:qr/src/error_correct_level.dart';
 import 'package:qr/src/qr_code.dart';
 import 'package:qr/src/qr_image.dart';
@@ -135,6 +136,40 @@ void main() {
         errorCorrectLevel: QrErrorCorrectLevel.H,
       );
       expect(qr.typeNumber, 2);
+    });
+  });
+
+  group('_calculateTypeNumberFromData - Version 40 Boundary Handling', () {
+    test('''
+      should generate a QrCode with version 40
+      for data slightly exceeding version 39 capacity
+      ''', () {
+      // 2952 bytes exceeds v39 (L) capacity of 2951.
+      final largeData = '|' * 2952;
+
+      final qrCode = QrCode.fromData(
+        data: largeData,
+        errorCorrectLevel: QrErrorCorrectLevel.L,
+      );
+
+      expect(qrCode.typeNumber, 40);
+    });
+
+    test('''
+      should throw InputTooLongException 
+      for data exceeding version 40 capacity
+      ''', () {
+      // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
+      final excessivelyLargeData = '|' * 2954;
+
+      // An exception should be thrown for data exceeding the capacity
+      expect(
+        () => QrCode.fromData(
+          data: excessivelyLargeData,
+          errorCorrectLevel: QrErrorCorrectLevel.L,
+        ),
+        throwsA(isA<InputTooLongException>()),
+      );
     });
   });
 }


### PR DESCRIPTION
Hello, @kevmoo ✋

I've been working on the issue we discussed and have a pull request ready for your review. I would appreciate it if you could take a look at your earliest convenience.

---

### Summary

This pull request addresses the issue of handling data that is too long to be encoded in any QR Code version (1-40).

The `_calculateTypeNumberFromData` method has been modified to explicitly throw an `InputTooLongException` when the data exceeds the capacity of Version 40. Previously, the method would return an invalid version number, which could lead to the generation of a broken QR Code object.

This change ensures that the library fails fast and informs the user when provided data cannot be encoded, significantly improving the robustness and reliability of the QR code generation process.

### Changes

-   **Added**: A new helper method `_calculateTotalDataBits` to centralize the logic for calculating data capacity.
-   **Modified**: `_calculateTypeNumberFromData` to use the new helper method and throw an `InputTooLongException` for excessively large data.
-   **Modified**: `_createData` to use the new helper method, removing redundant code.
-   **Updated**: Unit tests to verify that `InputTooLongException` is thrown correctly for data exceeding Version 40's capacity.

### Related Issue

resolves #110