### PR TITLE
feat: Add automatic mode detection to addData method (fixes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.0-wip
 
-- `QrCode.fromData` now intelligently picks the right mode.
+- `QrCode.fromData` and `QrCode.addData` 
+  now intelligently pick the right mode.
 - Require `sdk: ^3.8.0`.
 
 ## 3.0.2

--- a/lib/src/qr_code.dart
+++ b/lib/src/qr_code.dart
@@ -83,7 +83,21 @@ class QrCode {
     return typeNumber;
   }
 
-  void addData(String data) => _addToList(QrByte(data));
+  void addData(String data) {
+    final QrDatum datum;
+    // Automatically determine mode here, just like QrCode.fromData
+    if (QrNumeric.validationRegex.hasMatch(data)) {
+      // Numeric mode for numbers only
+      datum = QrNumeric.fromString(data);
+    } else if (QrAlphaNumeric.validationRegex.hasMatch(data)) {
+      // Alphanumeric mode for alphanumeric characters only
+      datum = QrAlphaNumeric.fromString(data);
+    } else {
+      // Default to byte mode for other characters
+      datum = QrByte(data);
+    }
+    _addToList(datum);
+  }
 
   void addByteData(ByteData data) => _addToList(QrByte.fromByteData(data));
 

--- a/test/qr_code_test.dart
+++ b/test/qr_code_test.dart
@@ -137,6 +137,31 @@ void main() {
       expect(qr.typeNumber, 2);
     });
   });
+
+  group('QrCode.addData Automatic Mode Detection', () {
+    // Numeric Mode
+    test('should use Numeric Mode for numbers', () {
+      // 9 numeric characters fit version 1 (H level).
+      final qr = QrCode(1, QrErrorCorrectLevel.H)..addData('123456789');
+      expect(qr.typeNumber, 1);
+    });
+
+    // Alphanumeric Mode
+    test('should use Alphanumeric Mode', () {
+      // 13 alphanumeric characters exceed version 1 (7 chars) but fit
+      // version 2 (H level, 16 chars).
+      final qr = QrCode(2, QrErrorCorrectLevel.H)..addData('HELLO WORLD A');
+      expect(qr.typeNumber, 2);
+    });
+
+    // Byte Mode
+    test('should use Byte Mode for non-alphanumeric characters', () {
+      // Kanji characters are UTF-8 encoded.
+      // '機械学習' (12 bytes) fits version 2 (H level, 16 bytes).
+      final qr = QrCode(2, QrErrorCorrectLevel.H)..addData('機械学習');
+      expect(qr.typeNumber, 2);
+    });
+  });
 }
 
 String _encodeBoolListToString(List<bool?> source) =>


### PR DESCRIPTION
Hello, @kevmoo ✋

I hope you're having a great day.

I've been looking through the issues and found one that seems related to the automatic mode detection logic we worked on previously in #108. It appears the addData method had a similar limitation, forcing certain numeric strings into an inefficient byte mode.

I've implemented a solution that adds the same robust mode detection to the addData method, ensuring it selects the most efficient encoding for the input data. This resolves the reported InputTooLongException for numeric strings.

I would appreciate it if you could review the changes at your convenience.

Thank you for your continued work on this repository and for your help!

--- 

# Summary

This pull request resolves the issue reported in #20, where the `addData` method would throw an `InputTooLongException` for certain types of data.

## Before this Change

The `addData` method would always encode the input string in **Byte mode**, regardless of its content. This prevented the use of more efficient modes like **Numeric mode** for purely numeric strings, often causing the QR code to exceed its capacity unnecessarily.

## After this Change

The `addData` method now includes the same **automatic mode detection logic** as the `fromData` factory constructor. This ensures that the most efficient encoding mode is automatically selected based on the input string: **Numeric mode** for digits, **Alphanumeric mode** for alphanumeric characters, and **Byte mode** for all others.

With this improvement, users can now use the `addData` method alone to achieve efficient encoding without having to call a specific method like `addNumeric`.

## Changes

- Added automatic mode detection logic to the `addData` method in the `QrCode` class.
- Added test cases to verify the new behavior of the `addData` method.

## Related Issue

Fixes #20