### PR TITLE
Add link to qr_image_exporter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ of scannable codes, include QR.
 
 # Exporting
 
-The following libraries can be used to export QR codes to a specific format:
+The following packages can be used to export QR codes directory to an image:
 
 * [qr_image_exporter](https://pub.dev/packages/qr_image_exporter) - A library to 
   export QR codes as PNG image data.


### PR DESCRIPTION
## PR Description

Hi @kevmoo,

Following up on my previous PR and your suggestion, I have published the PNG export functionality as a separate, lightweight package: [qr_image_exporter](https://pub.dev/packages/qr_image_exporter).

This PR adds a link to the new package in the README. Based on the feedback from the code assistant, I've created a dedicated "Exporting" section to clearly distinguish it from UI-based libraries. This directly addresses the long-standing request in #62 by providing users with a clear solution for generating image data.

This approach allows the core qr.dart package to remain dependency-free while improving discoverability for this common use case.

## Changes:

- Added a new "Exporting" section to README.md.
- Added a link to qr_image_exporter in README.md.


Thank you for the guidance on this!