### PR TITLE
⚡ optimize QR data allocation by pre-allocating Uint8List

### DIFF
--- a/lib/src/qr_code.dart
+++ b/lib/src/qr_code.dart
@@ -292,20 +292,28 @@ List<int> _createBytes(QrBitBuffer buffer, List<QrRsBlock> rsBlocks) {
     }
   }
 
-  final data = <int>[];
+  var totalCount = 0;
+  for (var i = 0; i < rsBlocks.length; i++) {
+    totalCount += rsBlocks[i].totalCount;
+  }
+
+  final data = Uint8List(totalCount);
+  var dataPtr = 0;
 
   for (var i = 0; i < maxDcCount; i++) {
     for (var r = 0; r < rsBlocks.length; r++) {
-      if (i < dcData[r]!.length) {
-        data.add(dcData[r]![i]);
+      final dcItem = dcData[r]!;
+      if (i < dcItem.length) {
+        data[dataPtr++] = dcItem[i];
       }
     }
   }
 
   for (var i = 0; i < maxEcCount; i++) {
     for (var r = 0; r < rsBlocks.length; r++) {
-      if (i < ecData[r]!.length) {
-        data.add(ecData[r]![i]);
+      final ecItem = ecData[r]!;
+      if (i < ecItem.length) {
+        data[dataPtr++] = ecItem[i];
       }
     }
   }


### PR DESCRIPTION
The `_createBytes` function in `lib/src/qr_code.dart` previously used a growable `List<int>` and called `add()` repeatedly to build the final QR data. This optimization calculates the total expected size from the Reed-Solomon blocks and pre-allocates a `Uint8List` of that size.

### Performance Impact:
In manual benchmarks of large QR code generation (Type 40), this change reduces the number of allocations and copies. While the overall execution time for smaller QR codes is dominated by polynomial math, this change improves memory efficiency and provides a measurable (though modest in total time) boost for larger codes by avoiding dynamic list growth.

### Correctness:
The logic was verified by generating QR codes and confirming that the output `dataCache` is a `Uint8List` of the correct length and contains the expected data. All existing logic for interleaving data and error correction bytes remains unchanged.

---
*PR created automatically by Jules for task [991114225832848258](https://jules.google.com/task/991114225832848258) started by @kevmoo*