### PR TITLE
🧪 [testing improvement] Add edge case test for QrAlphaNumeric.write with 1 leftover character

### DIFF
--- a/test/qr_alphanumeric_test.dart
+++ b/test/qr_alphanumeric_test.dart
@@ -12,7 +12,7 @@ void main() {
     qr.write(buffer);
     expect(buffer, hasLength(248));
     expect(
-      buffer.map<String>((e) => e ? '1' : '0').join(),
+      buffer.map<String>((bool e) => e ? '1' : '0').join(),
       '00000000001'
       '00001011101'
       '00010111001'
@@ -46,7 +46,21 @@ void main() {
     final buffer = QrBitBuffer();
     qr.write(buffer);
     expect(buffer, hasLength(6));
-    expect(buffer.map<String>((e) => e ? '1' : '0').join(), '100101');
+    expect(buffer.map<String>((bool e) => e ? '1' : '0').join(), '100101');
+  });
+
+  test('triple alphanumeric', () {
+    final qr = QrAlphaNumeric.fromString('ABC');
+    expect(qr.mode, QrMode.alphaNumeric);
+    expect(qr.length, 3);
+    final buffer = QrBitBuffer();
+    qr.write(buffer);
+    expect(buffer, hasLength(17), reason: '(1*11) + 6 = 17');
+    expect(
+      buffer.map<String>((bool e) => e ? '1' : '0').join(),
+      '00111001101' // 461
+      '001100', // 12
+    );
   });
 
   test('double (even) alphanumeric', () {
@@ -59,10 +73,10 @@ void main() {
     expect(
       buffer
           .getRange(0, 11)
-          .map<int>((e) => e ? 1 : 0)
+          .map<int>((bool e) => e ? 1 : 0)
           .fold<int>(
             0,
-            (previousValue, element) => (previousValue << 1) | element,
+            (int previousValue, int element) => (previousValue << 1) | element,
           ),
       170,
     );


### PR DESCRIPTION
This PR adds a new test case for `QrAlphaNumeric.write` in `test/qr_alphanumeric_test.dart` to cover the scenario where an input string has an odd number of characters (specifically length 3), resulting in a single leftover character that needs to be encoded in 6 bits after the initial pairs are processed in 11-bit chunks. It also improves type safety in the test file by adding explicit type annotations to satisfy strict analysis rules.

---
*PR created automatically by Jules for task [17466197521017709421](https://jules.google.com/task/17466197521017709421) started by @kevmoo*