### PR TITLE
fix(security): truncate unsanitized user input in exception messages

### DIFF
--- a/lib/src/byte.dart
+++ b/lib/src/byte.dart
@@ -73,8 +73,12 @@ class QrNumeric implements QrDatum {
 
   factory QrNumeric.fromString(String numberString) {
     if (!validationRegex.hasMatch(numberString)) {
+      final value =
+          numberString.length > 10
+              ? '${numberString.substring(0, 10)}...'
+              : numberString;
       throw ArgumentError.value(
-        numberString,
+        value,
         'numberString',
         'string can only contain digits 0-9',
       );
@@ -142,8 +146,12 @@ class QrAlphaNumeric implements QrDatum {
 
   factory QrAlphaNumeric.fromString(String alphaNumeric) {
     if (!alphaNumeric.contains(validationRegex)) {
+      final value =
+          alphaNumeric.length > 10
+              ? '${alphaNumeric.substring(0, 10)}...'
+              : alphaNumeric;
       throw ArgumentError.value(
-        alphaNumeric,
+        value,
         'alphaNumeric',
         'String does not contain valid ALPHA-NUM character set',
       );

--- a/test/security_vulnerability_test.dart
+++ b/test/security_vulnerability_test.dart
@@ -1,0 +1,50 @@
+import 'package:qr/qr.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Security: Unsanitized User Input in Exception Message', () {
+    test(
+      'QrNumeric.fromString should not include long unsanitized input in ArgumentError',
+      () {
+        final longInvalidInput = '123a${'4' * 1000}';
+        try {
+          QrNumeric.fromString(longInvalidInput);
+          fail('Should have thrown ArgumentError');
+        } catch (e) {
+          expect(e, isA<ArgumentError>());
+          final errorString = e.toString();
+          // The error message should not contain the full long input
+          expect(
+            errorString.length,
+            lessThan(200),
+            reason:
+                'Error message is too long, might contain unsanitized input',
+          );
+          expect(errorString, contains('123a444444...'));
+        }
+      },
+    );
+
+    test(
+      'QrAlphaNumeric.fromString should not include long unsanitized input in ArgumentError',
+      () {
+        final longInvalidInput = 'ABC!${'D' * 1000}';
+        try {
+          QrAlphaNumeric.fromString(longInvalidInput);
+          fail('Should have thrown ArgumentError');
+        } catch (e) {
+          expect(e, isA<ArgumentError>());
+          final errorString = e.toString();
+          // The error message should not contain the full long input
+          expect(
+            errorString.length,
+            lessThan(200),
+            reason:
+                'Error message is too long, might contain unsanitized input',
+          );
+          expect(errorString, contains('ABC!DDDDDD...'));
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
To prevent potential log injection and resource exhaustion (DoS) via excessively large error strings, truncate invalid user-provided input in ArgumentError messages. Includes new regression tests.