### PR TITLE
Add autosubmit workflow

### DIFF
--- a/.github/workflows/autosubmit.yml
+++ b/.github/workflows/autosubmit.yml
@@ -1,0 +1,20 @@
+name: Autosubmit
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  autosubmit:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'autosubmit')
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the autosubmit GitHub Actions workflow to enable automatic merging of PRs when the `autosubmit` label is set.