### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1-dev
+
+- Migrate test suite to `package:checks`.
+
 ## 4.0.0
 
 - **Breaking Change**: Removed `QrBitBuffer` from public exports to tighten the API surface.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: qr
-version: 4.0.0
+version: 4.0.1-dev
 description: >-
   A QR code generation library for Dart.
   Supports QR code version 1 through 40, error correction and redundancy.
@@ -20,6 +20,7 @@ dev_dependencies:
   build_runner: ^2.2.1
   build_web_compilers: ^4.1.4
   characters: ^1.4.1
+  checks: ^0.3.1
   dart_flutter_team_lints: ^3.0.0
   path: ^1.9.1
   test: ^1.21.6

--- a/test/eci_test.dart
+++ b/test/eci_test.dart
@@ -1,55 +1,56 @@
 // ignore_for_file: lines_longer_than_80_chars
 
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
 import 'package:qr/src/bit_buffer.dart';
 import 'package:qr/src/eci.dart';
 import 'package:qr/src/mode.dart' as qr_mode;
 import 'package:qr/src/qr_code.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('QrEci', () {
     test('validates value range', () {
-      expect(() => QrEci(-1), throwsArgumentError);
-      expect(() => QrEci(1000000), throwsArgumentError);
-      expect(QrEci(0).value, 0);
-      expect(QrEci(999999).value, 999999);
+      check(() => QrEci(const QrEciValue(-1))).throws<ArgumentError>();
+      check(() => QrEci(const QrEciValue(1000000))).throws<ArgumentError>();
+      check<int>(QrEci(const QrEciValue(0)).value).equals(0);
+      check<int>(QrEci(const QrEciValue(999999)).value).equals(999999);
     });
 
     test('constants', () {
-      expect(QrEciValue.iso8859_1, 3);
-      expect(QrEciValue.iso8859_2, 4);
-      expect(QrEciValue.iso8859_3, 5);
-      expect(QrEciValue.iso8859_4, 6);
-      expect(QrEciValue.iso8859_5, 7);
-      expect(QrEciValue.iso8859_6, 8);
-      expect(QrEciValue.iso8859_7, 9);
-      expect(QrEciValue.iso8859_8, 10);
-      expect(QrEciValue.iso8859_9, 11);
-      expect(QrEciValue.iso8859_10, 12);
-      expect(QrEciValue.iso8859_11, 13);
-      expect(QrEciValue.iso8859_13, 15);
-      expect(QrEciValue.iso8859_14, 16);
-      expect(QrEciValue.iso8859_15, 17);
-      expect(QrEciValue.iso8859_16, 18);
-      expect(QrEciValue.shiftJis, 20);
-      expect(QrEciValue.windows1250, 21);
-      expect(QrEciValue.windows1251, 22);
-      expect(QrEciValue.windows1252, 23);
-      expect(QrEciValue.windows1256, 24);
-      expect(QrEciValue.utf16BE, 25);
-      expect(QrEciValue.utf8, 26);
-      expect(QrEciValue.ascii, 27);
-      expect(QrEciValue.big5, 28);
-      expect(QrEciValue.gb2312, 29);
-      expect(QrEciValue.eucKr, 30);
-      expect(QrEciValue.gbk, 31);
+      check<int>(QrEciValue.iso8859_1).equals(3);
+      check<int>(QrEciValue.iso8859_2).equals(4);
+      check<int>(QrEciValue.iso8859_3).equals(5);
+      check<int>(QrEciValue.iso8859_4).equals(6);
+      check<int>(QrEciValue.iso8859_5).equals(7);
+      check<int>(QrEciValue.iso8859_6).equals(8);
+      check<int>(QrEciValue.iso8859_7).equals(9);
+      check<int>(QrEciValue.iso8859_8).equals(10);
+      check<int>(QrEciValue.iso8859_9).equals(11);
+      check<int>(QrEciValue.iso8859_10).equals(12);
+      check<int>(QrEciValue.iso8859_11).equals(13);
+      check<int>(QrEciValue.iso8859_13).equals(15);
+      check<int>(QrEciValue.iso8859_14).equals(16);
+      check<int>(QrEciValue.iso8859_15).equals(17);
+      check<int>(QrEciValue.iso8859_16).equals(18);
+      check<int>(QrEciValue.shiftJis).equals(20);
+      check<int>(QrEciValue.windows1250).equals(21);
+      check<int>(QrEciValue.windows1251).equals(22);
+      check<int>(QrEciValue.windows1252).equals(23);
+      check<int>(QrEciValue.windows1256).equals(24);
+      check<int>(QrEciValue.utf16BE).equals(25);
+      check<int>(QrEciValue.utf8).equals(26);
+      check<int>(QrEciValue.ascii).equals(27);
+      check<int>(QrEciValue.big5).equals(28);
+      check<int>(QrEciValue.gb2312).equals(29);
+      check<int>(QrEciValue.eucKr).equals(30);
+      check<int>(QrEciValue.gbk).equals(31);
     });
 
     test('properties', () {
-      final eci = QrEci(123);
-      expect(eci.mode, qr_mode.QrMode.eci);
-      expect(eci.length, 0);
+      final eci = QrEci(const QrEciValue(123));
+      check(eci.mode).equals(qr_mode.QrMode.eci);
+      check(eci.length).equals(0);
     });
 
     test('encodes 0-127 (8 bits)', () {
@@ -97,21 +98,24 @@ void main() {
     ];
 
     // Verify the full data cache (19 Data Codewords for Version 1-L)
-    expect(getDataCache(code).sublist(0, 19), expectedData);
+    check(getDataCache(code).sublist(0, 19)).deepEquals(expectedData);
 
     final image = QrImage(code);
-    expect(image.moduleCount, 21); // Version 1 is 21x21
-    expect(_getModules(image), _expectedEmojiModules);
+    check(image.moduleCount).equals(21); // Version 1 is 21x21
+    check(_getModules(image)).deepEquals(_expectedEmojiModules);
   });
 }
 
 void _testEci(int value, List<int> expectedBytes) {
   final buffer = QrBitBuffer();
-  QrEci(value).write(buffer);
+  QrEci(QrEciValue(value)).write(buffer);
 
-  expect(buffer, hasLength(expectedBytes.length * 8));
+  check(buffer.length).equals(expectedBytes.length * 8);
   for (var i = 0; i < expectedBytes.length; i++) {
-    expect(buffer.getByte(i), expectedBytes[i], reason: 'Byte $i mismatch');
+    check(
+      because: 'Byte $i mismatch',
+      buffer.getByte(i),
+    ).equals(expectedBytes[i]);
   }
 }
 

--- a/test/eci_test.dart
+++ b/test/eci_test.dart
@@ -11,10 +11,10 @@ import 'package:test/scaffolding.dart';
 void main() {
   group('QrEci', () {
     test('validates value range', () {
-      check(() => QrEci(const QrEciValue(-1))).throws<ArgumentError>();
-      check(() => QrEci(const QrEciValue(1000000))).throws<ArgumentError>();
-      check<int>(QrEci(const QrEciValue(0)).value).equals(0);
-      check<int>(QrEci(const QrEciValue(999999)).value).equals(999999);
+      check(() => QrEci(-1)).throws<RangeError>();
+      check(() => QrEci(1000000)).throws<RangeError>();
+      check(QrEci(0).value).equals(0);
+      check(QrEci(999999).value).equals(999999);
     });
 
     test('constants', () {
@@ -48,7 +48,7 @@ void main() {
     });
 
     test('properties', () {
-      final eci = QrEci(const QrEciValue(123));
+      final eci = QrEci(123);
       check(eci.mode).equals(qr_mode.QrMode.eci);
       check(eci.length).equals(0);
     });
@@ -108,7 +108,7 @@ void main() {
 
 void _testEci(int value, List<int> expectedBytes) {
   final buffer = QrBitBuffer();
-  QrEci(QrEciValue(value)).write(buffer);
+  QrEci(value).write(buffer);
 
   check(buffer.length).equals(expectedBytes.length * 8);
   for (var i = 0; i < expectedBytes.length; i++) {

--- a/test/example_model_test.dart
+++ b/test/example_model_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 import '../example/src/example_model.dart';
 
@@ -7,11 +8,11 @@ void main() {
   group('ExampleModel', () {
     test('initial state is question', () {
       final model = ExampleModel();
-      expect(model.state, ExampleState.question);
-      expect(model.squares, isEmpty);
-      expect(model.moduleCount, 0);
-      expect(model.validTypeNumbers, hasLength(10));
-      expect(model.validErrorCorrectLevels, hasLength(4));
+      check(model.state).equals(ExampleState.question);
+      check(model.squares).isEmpty();
+      check(model.moduleCount).equals(0);
+      check(model.validTypeNumbers).length.equals(10);
+      check(model.validErrorCorrectLevels).length.equals(4);
     });
 
     test('valid input generates QR squares', () {
@@ -23,11 +24,11 @@ void main() {
       addTearDown(sub.cancel);
 
       model.value = 'Hello World';
-      expect(notified, isTrue);
-      expect(model.state, ExampleState.qr);
-      expect(model.squares, isNotEmpty);
-      expect(model.moduleCount, greaterThan(0));
-      expect(model.validTypeNumbers, contains(2));
+      check(notified).isTrue();
+      check(model.state).equals(ExampleState.qr);
+      check(model.squares).isNotEmpty();
+      check(model.moduleCount).isGreaterThan(0);
+      check(model.validTypeNumbers).contains(2);
     });
 
     test('input exceeding version limit transitions to error state', () {
@@ -36,18 +37,18 @@ void main() {
         ..typeNumber =
             1 // Force version 1
         ..value = 'A' * 100; // Exceeds version 1 capacity
-      expect(model.state, ExampleState.error);
-      expect(model.squares, isEmpty);
-      expect(model.moduleCount, 0);
+      check(model.state).equals(ExampleState.error);
+      check(model.squares).isEmpty();
+      check(model.moduleCount).equals(0);
     });
 
     test('autoType automatically bumps typeNumber when needed', () {
       final model = ExampleModel();
-      expect(model.autoType, isTrue);
+      check(model.autoType).isTrue();
 
       model.value = 'A' * 150; // Exceeds version 1 but fits in higher version
-      expect(model.state, ExampleState.qr);
-      expect(model.typeNumber, greaterThan(1));
+      check(model.state).equals(ExampleState.qr);
+      check(model.typeNumber).isGreaterThan(1);
     });
 
     test('getters, setters, and dispose', () {
@@ -58,11 +59,11 @@ void main() {
 
       model.changes.listen((_) {}).cancel();
 
-      expect(model.value, 'Test');
-      expect(model.byteCount, 4);
+      check(model.value).equals('Test');
+      check(model.byteCount).equals(4);
 
-      expect(model.errorCorrectLevel, QrErrorCorrectLevel.low);
-      expect(model.validErrorCorrectLevels, isNotEmpty);
+      check(model.errorCorrectLevel).equals(QrErrorCorrectLevel.low);
+      check(model.validErrorCorrectLevels).isNotEmpty();
     });
 
     test(
@@ -77,53 +78,47 @@ void main() {
           ..autoType = true
           ..value = 'A' * 50;
 
-        expect(model.state, ExampleState.qr);
-        expect(model.typeNumber, greaterThan(1));
-        expect(
-          model.validErrorCorrectLevels,
-          contains(QrErrorCorrectLevel.high),
-        );
+        check(model.state).equals(ExampleState.qr);
+        check(model.typeNumber).isGreaterThan(1);
+        check(model.validErrorCorrectLevels).contains(QrErrorCorrectLevel.high);
       },
     );
 
     test('clearing input with autoType enabled resets typeNumber to 1', () {
       final model = ExampleModel()..value = 'A' * 150;
-      expect(model.typeNumber, greaterThan(1));
+      check(model.typeNumber).isGreaterThan(1);
 
       model.value = '';
-      expect(model.typeNumber, 1);
+      check(model.typeNumber).equals(1);
     });
 
     test(
       'autoType maintains all validErrorCorrectLevels across version tiers',
       () {
         final model = ExampleModel();
-        expect(model.autoType, isTrue);
+        check(model.autoType).isTrue();
 
         // 60 characters exceeds Version 1 High capacity (7 chars)
         // but fits in Version 3 High.
         model.value = 'A' * 60;
 
-        expect(
-          model.validErrorCorrectLevels,
-          contains(QrErrorCorrectLevel.high),
-        );
+        check(model.validErrorCorrectLevels).contains(QrErrorCorrectLevel.high);
       },
     );
 
     test('autoType supports overflow versions beyond maxTypeNumber without '
         'blocking', () {
       final model = ExampleModel();
-      expect(model.autoType, isTrue);
+      check(model.autoType).isTrue();
 
       // 400 characters exceeds Version 10 High capacity (174 chars).
       // It fits in Version 14 High (458 chars).
       model.value = 'A' * 400;
 
-      expect(model.state, ExampleState.qr);
-      expect(model.typeNumber, 17);
-      expect(model.validTypeNumbers, contains(17));
-      expect(model.squares, isNotEmpty);
+      check(model.state).equals(ExampleState.qr);
+      check(model.typeNumber).equals(17);
+      check(model.validTypeNumbers).contains(17);
+      check(model.squares).isNotEmpty();
     });
   });
 }

--- a/test/fuzz_test.dart
+++ b/test/fuzz_test.dart
@@ -1,9 +1,10 @@
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
 import 'package:qr/src/qr_code.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   final random = Random(42); // Fixed seed for reproducibility
@@ -24,12 +25,12 @@ void main() {
           errorCorrectLevel: level,
         );
         // Ensure we can at least generate the data cache without crashing
-        expect(getDataCache(qr), isNotEmpty);
+        check(getDataCache(qr)).isNotEmpty();
 
         // Also test random mask patterns
         final mask = random.nextInt(8);
         final image = QrImage.withMaskPattern(qr, mask);
-        expect(image.qrModules, isNotEmpty);
+        check(image.qrModules).isNotEmpty();
       } catch (e) {
         // We expect InputTooLongException for large data, but nothing else
         if (e is! InputTooLongException) {
@@ -55,7 +56,7 @@ void main() {
           payload: QrPayload.fromTypedData(data),
           errorCorrectLevel: level,
         );
-        expect(getDataCache(qr), isNotEmpty);
+        check(getDataCache(qr)).isNotEmpty();
       } catch (e) {
         if (e is! InputTooLongException) {
           print('Failed with input bytes of length $length at iteration $i');
@@ -114,7 +115,7 @@ void main() {
           errorCorrectLevel: level,
           minTypeNumber: type,
         );
-        expect(getDataCache(qr), isNotEmpty);
+        check(getDataCache(qr)).isNotEmpty();
       } catch (e) {
         if (e is! InputTooLongException && e is! ArgumentError) {
           print('Failed during manual addition at iteration $i');

--- a/test/qr_alphanumeric_test.dart
+++ b/test/qr_alphanumeric_test.dart
@@ -1,21 +1,21 @@
 import 'package:characters/characters.dart';
+import 'package:checks/checks.dart';
 import 'package:qr/src/bit_buffer.dart';
 import 'package:qr/src/byte.dart';
 import 'package:qr/src/mode.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('full character map', () {
     final qr = QrAlphaNumeric.fromString(
       r'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:',
     );
-    expect(qr.mode, QrMode.alphaNumeric);
-    expect(qr.length, 45);
+    check(qr.mode).equals(QrMode.alphaNumeric);
+    check(qr.length).equals(45);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(248));
-    expect(
-      buffer.toString(),
+    check(buffer.length).equals(248);
+    check(buffer.toString()).equals(
       '00000000001'
       '00001011101'
       '00010111001'
@@ -44,23 +44,22 @@ void main() {
 
   test('single alphanumeric', () {
     final qr = QrAlphaNumeric.fromString(r'$');
-    expect(qr.mode, QrMode.alphaNumeric);
-    expect(qr.length, 1);
+    check(qr.mode).equals(QrMode.alphaNumeric);
+    check(qr.length).equals(1);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(6));
-    expect(buffer.toString(), '100101');
+    check(buffer.length).equals(6);
+    check(buffer.toString()).equals('100101');
   });
 
   test('triple alphanumeric', () {
     final qr = QrAlphaNumeric.fromString('ABC');
-    expect(qr.mode, QrMode.alphaNumeric);
-    expect(qr.length, 3);
+    check(qr.mode).equals(QrMode.alphaNumeric);
+    check(qr.length).equals(3);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(17), reason: '(1*11) + 6 = 17');
-    expect(
-      buffer.toString(),
+    check(because: '(1*11) + 6 = 17', buffer.length).equals(17);
+    check(buffer.toString()).equals(
       '00111001101' // 461
       '001100', // 12
     );
@@ -68,12 +67,12 @@ void main() {
 
   test('double (even) alphanumeric', () {
     final qr = QrAlphaNumeric.fromString('3Z');
-    expect(qr.mode, QrMode.alphaNumeric);
-    expect(qr.length, 2);
+    check(qr.mode).equals(QrMode.alphaNumeric);
+    check(qr.length).equals(2);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(11), reason: 'n*5+1 = 11');
-    expect(buffer.toString(), '00010101010');
+    check(because: 'n*5+1 = 11', buffer.length).equals(11);
+    check(buffer.toString()).equals('00010101010');
   });
 
   test('throws on invalid input', () {
@@ -84,10 +83,9 @@ void main() {
 
 void _checkInvalid(String input, String description) {
   for (final character in input.characters) {
-    expect(
+    check(
+      because: '$description $character is invalid',
       () => QrAlphaNumeric.fromString(character),
-      throwsArgumentError,
-      reason: '$description $character is invalid',
-    );
+    ).throws<ArgumentError>();
   }
 }

--- a/test/qr_bit_buffer_test.dart
+++ b/test/qr_bit_buffer_test.dart
@@ -1,7 +1,8 @@
 import 'dart:math' as math;
 
+import 'package:checks/checks.dart';
 import 'package:qr/src/bit_buffer.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('simple', _testSimple);
@@ -12,30 +13,30 @@ void main() {
 
 void _testGetByte() {
   var bb = QrBitBuffer()..put(12, 8);
-  expect(bb.getByte(0), equals(12));
+  check(bb.getByte(0)).equals(12);
 
   bb = QrBitBuffer()..put(42, 8);
-  expect(bb.getByte(0), equals(42));
+  check(bb.getByte(0)).equals(42);
 
   bb.put(19, 8);
-  expect(bb.getByte(1), equals(19));
+  check(bb.getByte(1)).equals(19);
 }
 
 void _testComplex() {
   var bb = QrBitBuffer()..put(0, 8);
-  expect(bb.toString(), '00000000');
+  check(bb.toString()).equals('00000000');
 
   bb = QrBitBuffer()..put(1, 8);
-  expect(bb.toString(), '00000001');
+  check(bb.toString()).equals('00000001');
 
   bb = QrBitBuffer()..put(255, 8);
-  expect(bb.toString(), '11111111');
+  check(bb.toString()).equals('11111111');
 
   bb = QrBitBuffer()..put(256, 8);
-  expect(bb.toString(), '00000000');
+  check(bb.toString()).equals('00000000');
 
   bb = QrBitBuffer()..put(256, 9);
-  expect(bb.toString(), '100000000');
+  check(bb.toString()).equals('100000000');
 }
 
 final _rnd = math.Random();
@@ -50,10 +51,10 @@ void _testSimple() {
     bb.put(b ? 1 : 0, 1);
   }
 
-  expect(bb.toString(), equals(sampleBits.map((b) => b ? '1' : '0').join()));
+  check(bb.toString()).equals(sampleBits.map((b) => b ? '1' : '0').join());
 }
 
 void _testBufferExpansion() {
   final buffer = QrBitBuffer()..put(0, 10000);
-  expect(buffer.length, 10000);
+  check(buffer.length).equals(10000);
 }

--- a/test/qr_byte_test.dart
+++ b/test/qr_byte_test.dart
@@ -1,8 +1,9 @@
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:qr/src/bit_buffer.dart';
 import 'package:qr/src/byte.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('fromByteData', () {
@@ -11,11 +12,11 @@ void main() {
       data.setUint8(i, i);
     }
     final qr = QrByte.fromByteData(data);
-    expect(qr.length, 256);
+    check(qr.length).equals(256);
     final buffer = QrBitBuffer();
     qr.write(buffer);
     for (var i = 0; i < 256; i++) {
-      expect(buffer.getByte(i), equals(i));
+      check(buffer.getByte(i)).equals(i);
     }
   });
 }

--- a/test/qr_code_test.dart
+++ b/test/qr_code_test.dart
@@ -2,10 +2,11 @@
 
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
 import 'package:qr/src/mode.dart';
 import 'package:qr/src/payload.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 import 'qr_code_test_data.dart';
 import 'qr_code_test_data_with_mask.dart';
@@ -22,9 +23,9 @@ void main() {
           ),
         );
         final modules = qr.qrModules;
-        expect(
-          modules.map(_encodeBoolListToString),
-          qrCodeTestData[typeNumber.toString()][quality.index.toString()],
+        check(modules.map(_encodeBoolListToString)).deepEquals(
+          qrCodeTestData[typeNumber.toString()][quality.index.toString()]
+              as List,
         );
       }
     }
@@ -39,10 +40,9 @@ void main() {
         ),
       );
       final modules = qr.qrModules;
-      expect(
+      check(
         modules.map(_encodeBoolListToString),
-        qrCodeTestData['1'][quality.index.toString()],
-      );
+      ).deepEquals(qrCodeTestData['1'][quality.index.toString()] as List);
     }
   });
 
@@ -57,10 +57,9 @@ void main() {
         ),
       );
       final modules = qr.qrModules;
-      expect(
+      check(
         modules.map(_encodeBoolListToString),
-        qrCodeTestData['1'][quality.index.toString()],
-      );
+      ).deepEquals(qrCodeTestData['1'][quality.index.toString()] as List);
     }
   });
 
@@ -74,16 +73,15 @@ void main() {
         mask,
       );
       final modules = qr.qrModules;
-      expect(
+      check(
         modules.map(_encodeBoolListToString),
-        qrCodeTestDataWithMask[mask.toString()],
-      );
+      ).deepEquals(qrCodeTestDataWithMask[mask.toString()] as List);
     }
   });
 
   test('WHEN provided mask pattern is smaller than 0, '
       'SHOULD throw an AssertionError', () {
-    expect(() {
+    check(() {
       QrImage.withMaskPattern(
         QrCode(
           payload: QrPayload.fromString('shanna!'),
@@ -91,12 +89,12 @@ void main() {
         ),
         -1,
       );
-    }, throwsA(isA<AssertionError>()));
+    }).throws<AssertionError>();
   });
 
   test('WHEN provided mask pattern is bigger than 7, '
       'SHOULD throw an AssertionError', () {
-    expect(() {
+    check(() {
       QrImage.withMaskPattern(
         QrCode(
           payload: QrPayload.fromString('shanna!'),
@@ -104,7 +102,7 @@ void main() {
         ),
         8,
       );
-    }, throwsA(isA<AssertionError>()));
+    }).throws<AssertionError>();
   });
   group('QrCode auto-sizing', () {
     // Numeric Mode
@@ -114,7 +112,7 @@ void main() {
         payload: QrPayload.fromString('123456789'),
         errorCorrectLevel: QrErrorCorrectLevel.high,
       );
-      expect(qr.typeNumber, 1);
+      check(qr.typeNumber).equals(1);
     });
 
     // Alphanumeric Mode
@@ -125,7 +123,7 @@ void main() {
         payload: QrPayload.fromString('HELLO WORLD A'),
         errorCorrectLevel: QrErrorCorrectLevel.high,
       );
-      expect(qr.typeNumber, 2);
+      check(qr.typeNumber).equals(2);
     });
 
     // Byte Mode
@@ -136,7 +134,7 @@ void main() {
         payload: QrPayload.fromString('機械学習'),
         errorCorrectLevel: QrErrorCorrectLevel.high,
       );
-      expect(qr.typeNumber, 2);
+      check(qr.typeNumber).equals(2);
     });
   });
 
@@ -144,19 +142,19 @@ void main() {
     // Numeric Mode
     test('should use Numeric Mode for numbers', () {
       final payload = QrPayload.fromString('123456789');
-      expect(payload.dataList.single.mode, QrMode.numeric);
+      check(payload.dataList.single.mode).equals(QrMode.numeric);
     });
 
     // Alphanumeric Mode
     test('should use Alphanumeric Mode', () {
       final payload = QrPayload.fromString('HELLO WORLD A');
-      expect(payload.dataList.single.mode, QrMode.alphaNumeric);
+      check(payload.dataList.single.mode).equals(QrMode.alphaNumeric);
     });
 
     // Byte Mode
     test('should use Byte Mode for non-alphanumeric characters', () {
       final payload = QrPayload.fromString('機械学習');
-      expect(payload.dataList.last.mode, QrMode.byte);
+      check(payload.dataList.last.mode).equals(QrMode.byte);
     });
   });
 
@@ -170,26 +168,22 @@ void main() {
         errorCorrectLevel: QrErrorCorrectLevel.low,
       );
 
-      expect(qrCode.typeNumber, 40);
+      check(qrCode.typeNumber).equals(40);
     });
 
     test('throw InputTooLongException for data exceeding v40 capacity', () {
       // Data size (2954 bytes) exceeds v40 capacity (2953 bytes).
       final excessivelyLargeData = '|' * 2954;
 
-      expect(
-        () => QrCode(
-          payload: QrPayload.fromString(excessivelyLargeData),
-          errorCorrectLevel: QrErrorCorrectLevel.low,
-        ),
-        throwsA(
-          isA<InputTooLongException>().having(
-            (e) => e.toString(),
-            'toString()',
-            'Input too long. 23652 > 23648',
-          ),
-        ),
-      );
+      check(
+            () => QrCode(
+              payload: QrPayload.fromString(excessivelyLargeData),
+              errorCorrectLevel: QrErrorCorrectLevel.low,
+            ),
+          )
+          .throws<InputTooLongException>()
+          .has((e) => e.toString(), 'toString()')
+          .equals('Input too long. 23652 > 23648');
     });
   });
 }

--- a/test/qr_datum_test.dart
+++ b/test/qr_datum_test.dart
@@ -1,36 +1,36 @@
 import 'dart:typed_data';
 
+import 'package:checks/checks.dart';
 import 'package:qr/src/byte.dart';
 import 'package:qr/src/eci.dart';
 import 'package:qr/src/mode.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('QrDatum.toDatums', () {
     test('Numeric', () {
       final datums = QrDatum.toDatums('123456');
-      expect(datums, hasLength(1));
-      expect(datums.first, isA<QrNumeric>());
+      check(datums).length.equals(1);
+      check(datums.first).isA<QrNumeric>();
     });
 
     test('AlphaNumeric', () {
       final datums = QrDatum.toDatums('HELLO WORLD');
-      expect(datums, hasLength(1));
-      expect(datums.first, isA<QrAlphaNumeric>());
+      check(datums).length.equals(1);
+      check(datums.first).isA<QrAlphaNumeric>();
     });
 
     test('Byte (Latin-1)', () {
       final datums = QrDatum.toDatums('Hello World!');
-      expect(datums, hasLength(1));
-      expect(datums.first, isA<QrByte>());
+      check(datums).length.equals(1);
+      check(datums.first).isA<QrByte>();
     });
 
     test('Byte (UTF-8 with ECI)', () {
       final datums = QrDatum.toDatums('Hello 🌍');
-      expect(datums, hasLength(2));
-      expect(datums[0], isA<QrEci>());
-      expect((datums[0] as QrEci).value, 26);
-      expect(datums[1], isA<QrByte>());
+      check(datums).length.equals(2);
+      check(datums[0]).isA<QrEci>().has((e) => e.value, 'value').equals(26);
+      check(datums[1]).isA<QrByte>();
     });
 
     test('Complex Emoji (UTF-8 with ECI)', () {
@@ -40,21 +40,20 @@ void main() {
           '\u{1F469}\u{1F3FD}\u{200D}\u{2764}\u{FE0F}\u{200D}'
           '\u{1F48B}\u{200D}\u{1F468}\u{1F3FE}';
       final datums = QrDatum.toDatums(complexEmoji);
-      expect(datums, hasLength(2));
-      expect(datums[0], isA<QrEci>());
-      expect((datums[0] as QrEci).value, 26);
-      expect(datums[1], isA<QrByte>());
+      check(datums).length.equals(2);
+      check(datums[0]).isA<QrEci>().has((e) => e.value, 'value').equals(26);
+      check(datums[1]).isA<QrByte>();
     });
   });
 
   group('QrMode getLengthBits', () {
     test('Kanji and ECI', () {
-      expect(QrMode.kanji.getLengthBits(1), 8);
-      expect(QrMode.kanji.getLengthBits(10), 10);
-      expect(QrMode.kanji.getLengthBits(27), 12);
-      expect(QrMode.eci.getLengthBits(1), 0);
-      expect(QrMode.eci.getLengthBits(10), 0);
-      expect(QrMode.eci.getLengthBits(27), 0);
+      check(QrMode.kanji.getLengthBits(1)).equals(8);
+      check(QrMode.kanji.getLengthBits(10)).equals(10);
+      check(QrMode.kanji.getLengthBits(27)).equals(12);
+      check(QrMode.eci.getLengthBits(1)).equals(0);
+      check(QrMode.eci.getLengthBits(10)).equals(0);
+      check(QrMode.eci.getLengthBits(27)).equals(0);
     });
   });
 
@@ -63,7 +62,7 @@ void main() {
       final fullList = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
       final subView = Uint8List.sublistView(fullList, 2, 5); // [3, 4, 5]
       final qrByte = QrByte.fromByteData(subView);
-      expect(qrByte.length, 3);
+      check(qrByte.length).equals(3);
     });
   });
 }

--- a/test/qr_image_test.dart
+++ b/test/qr_image_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   late QrImage qrImage;
@@ -15,28 +16,26 @@ void main() {
   });
 
   test('should throw RangeError when row is less than 0', () {
-    expect(() => qrImage.isDark(-1, 0), throwsRangeError);
+    check(() => qrImage.isDark(-1, 0)).throws<RangeError>();
   });
 
   test('should throw RangeError when row is greater than '
       'or equal to moduleCount', () {
-    expect(() => qrImage.isDark(moduleCount, 0), throwsRangeError);
+    check(() => qrImage.isDark(moduleCount, 0)).throws<RangeError>();
   });
 
   test('should throw RangeError when col is less than 0', () {
-    expect(() => qrImage.isDark(0, -1), throwsRangeError);
+    check(() => qrImage.isDark(0, -1)).throws<RangeError>();
   });
 
   test('should throw RangeError when col is greater than '
       'or equal to moduleCount', () {
-    expect(() => qrImage.isDark(0, moduleCount), throwsRangeError);
+    check(() => qrImage.isDark(0, moduleCount)).throws<RangeError>();
   });
 
   test('should not throw when row and col are within valid range', () {
-    expect(() => qrImage.isDark(0, 0), returnsNormally);
-    expect(
-      () => qrImage.isDark(moduleCount - 1, moduleCount - 1),
-      returnsNormally,
-    );
+    qrImage
+      ..isDark(0, 0)
+      ..isDark(moduleCount - 1, moduleCount - 1);
   });
 }

--- a/test/qr_image_test.dart
+++ b/test/qr_image_test.dart
@@ -34,8 +34,9 @@ void main() {
   });
 
   test('should not throw when row and col are within valid range', () {
-    qrImage
-      ..isDark(0, 0)
-      ..isDark(moduleCount - 1, moduleCount - 1);
+    check(() => qrImage.isDark(0, 0)).returnsNormally();
+    check(
+      () => qrImage.isDark(moduleCount - 1, moduleCount - 1),
+    ).returnsNormally();
   });
 }

--- a/test/qr_numeric_test.dart
+++ b/test/qr_numeric_test.dart
@@ -1,18 +1,18 @@
+import 'package:checks/checks.dart';
 import 'package:qr/src/bit_buffer.dart';
 import 'package:qr/src/byte.dart';
 import 'package:qr/src/mode.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('all digits 1 through 0', () {
     final qr = QrNumeric.fromString('1234567890');
-    expect(qr.mode, QrMode.numeric);
-    expect(qr.length, 10);
+    check(qr.mode).equals(QrMode.numeric);
+    check(qr.length).equals(10);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(34));
-    expect(
-      buffer.toString(),
+    check(buffer.length).equals(34);
+    check(buffer.toString()).equals(
       '0001111011'
       '0111001000'
       '1100010101'
@@ -22,36 +22,36 @@ void main() {
 
   test('single numeric', () {
     final qr = QrNumeric.fromString('5');
-    expect(qr.mode, QrMode.numeric);
-    expect(qr.length, 1);
+    check(qr.mode).equals(QrMode.numeric);
+    check(qr.length).equals(1);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(4));
-    expect(buffer.toString(), '0101');
+    check(buffer.length).equals(4);
+    check(buffer.toString()).equals('0101');
   });
 
   test('double numeric', () {
     final qr = QrNumeric.fromString('37');
-    expect(qr.mode, QrMode.numeric);
-    expect(qr.length, 2);
-    expect(qr.bitLength, 7);
+    check(qr.mode).equals(QrMode.numeric);
+    check(qr.length).equals(2);
+    check(qr.bitLength).equals(7);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(7), reason: 'n*3+1 = 7');
-    expect(buffer.toString(), '0100101');
+    check(because: 'n*3+1 = 7', buffer.length).equals(7);
+    check(buffer.toString()).equals('0100101');
   });
 
   test('triple (even) numeric', () {
     final qr = QrNumeric.fromString('371');
-    expect(qr.mode, QrMode.numeric);
-    expect(qr.length, 3);
+    check(qr.mode).equals(QrMode.numeric);
+    check(qr.length).equals(3);
     final buffer = QrBitBuffer();
     qr.write(buffer);
-    expect(buffer, hasLength(10), reason: 'n*3+1 = 10');
-    expect(buffer.toString(), '0101110011');
+    check(because: 'n*3+1 = 10', buffer.length).equals(10);
+    check(buffer.toString()).equals('0101110011');
   });
 
   test('throws on invalid input', () {
-    expect(() => QrNumeric.fromString('hello'), throwsArgumentError);
+    check(() => QrNumeric.fromString('hello')).throws<ArgumentError>();
   });
 }

--- a/test/security_vulnerability_test.dart
+++ b/test/security_vulnerability_test.dart
@@ -1,44 +1,29 @@
+import 'package:checks/checks.dart';
 import 'package:qr/src/byte.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   group('Security: Unsanitized User Input in Exception Message', () {
     test('QrNumeric.fromString should not include long unsanitized input '
         'in ArgumentError', () {
       final longInvalidInput = '123a${'4' * 1000}';
-      try {
-        QrNumeric.fromString(longInvalidInput);
-        fail('Should have thrown ArgumentError');
-      } catch (e) {
-        expect(e, isA<ArgumentError>());
-        final errorString = e.toString();
-        // The error message should not contain the full long input
-        expect(
-          errorString.length,
-          lessThan(200),
-          reason: 'Error message is too long, might contain unsanitized input',
-        );
-        expect(errorString, contains('123a444444...'));
-      }
+      final errorStringSubject = check(
+        () => QrNumeric.fromString(longInvalidInput),
+      ).throws<ArgumentError>().has((e) => e.toString(), 'toString()');
+
+      errorStringSubject.length.isLessThan(200);
+      errorStringSubject.contains('123a444444...');
     });
 
     test('QrAlphaNumeric.fromString should not include long unsanitized input '
         'in ArgumentError', () {
       final longInvalidInput = 'ABC!${'D' * 1000}';
-      try {
-        QrAlphaNumeric.fromString(longInvalidInput);
-        fail('Should have thrown ArgumentError');
-      } catch (e) {
-        expect(e, isA<ArgumentError>());
-        final errorString = e.toString();
-        // The error message should not contain the full long input
-        expect(
-          errorString.length,
-          lessThan(200),
-          reason: 'Error message is too long, might contain unsanitized input',
-        );
-        expect(errorString, contains('ABC!DDDDDD...'));
-      }
+      final errorStringSubject = check(
+        () => QrAlphaNumeric.fromString(longInvalidInput),
+      ).throws<ArgumentError>().has((e) => e.toString(), 'toString()');
+
+      errorStringSubject.length.isLessThan(200);
+      errorStringSubject.contains('ABC!DDDDDD...');
     });
   });
 }

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -13,11 +13,9 @@ void main() {
       );
 
       check(result.isValid).isTrue();
-      check(
-        result.qrCode,
-      ).isNotNull().has((q) => q.typeNumber, 'typeNumber').equals(1);
-      check(result.qrCode)
-          .isNotNull()
+      final qrCode = check(result.qrCode).isNotNull();
+      qrCode.has((q) => q.typeNumber, 'typeNumber').equals(1);
+      qrCode
           .has((q) => q.errorCorrectLevel, 'errorCorrectLevel')
           .equals(QrErrorCorrectLevel.medium);
       check(result.validTypeNumbers).contains(1);

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test(
@@ -11,15 +12,18 @@ void main() {
         errorCorrectLevel: QrErrorCorrectLevel.medium,
       );
 
-      expect(result.isValid, isTrue);
-      expect(result.qrCode, isNotNull);
-      expect(result.qrCode!.typeNumber, 1);
-      expect(result.qrCode!.errorCorrectLevel, QrErrorCorrectLevel.medium);
-      expect(result.validTypeNumbers, contains(1));
-      expect(
+      check(result.isValid).isTrue();
+      check(
+        result.qrCode,
+      ).isNotNull().has((q) => q.typeNumber, 'typeNumber').equals(1);
+      check(result.qrCode)
+          .isNotNull()
+          .has((q) => q.errorCorrectLevel, 'errorCorrectLevel')
+          .equals(QrErrorCorrectLevel.medium);
+      check(result.validTypeNumbers).contains(1);
+      check(
         result.validErrorCorrectLevels,
-        contains(QrErrorCorrectLevel.medium),
-      );
+      ).contains(QrErrorCorrectLevel.medium);
     },
   );
 
@@ -36,15 +40,15 @@ void main() {
       errorCorrectLevel: QrErrorCorrectLevel.high,
     );
 
-    expect(result.isValid, isFalse);
-    expect(result.qrCode, isNull);
+    check(result.isValid).isFalse();
+    check(result.qrCode).isNull();
 
     // Type 1 should NOT be in valid types
-    expect(result.validTypeNumbers, isNot(contains(1)));
+    check(result.validTypeNumbers).not((it) => it.contains(1));
 
     // But some higher types SHOULD be valid
-    expect(result.validTypeNumbers, isNotEmpty);
-    expect(result.validTypeNumbers.last, 40);
+    check(result.validTypeNumbers).isNotEmpty();
+    check(result.validTypeNumbers.last).equals(40);
   });
 
   test('QrValidationResult.fromPayload validates error levels', () {
@@ -59,10 +63,9 @@ void main() {
       errorCorrectLevel: QrErrorCorrectLevel.low,
     );
 
-    expect(result.isValid, isTrue);
-    expect(
+    check(result.isValid).isTrue();
+    check(
       result.validErrorCorrectLevels,
-      unorderedEquals([QrErrorCorrectLevel.low, QrErrorCorrectLevel.medium]),
-    );
+    ).unorderedEquals([QrErrorCorrectLevel.low, QrErrorCorrectLevel.medium]);
   });
 }

--- a/test/verify_emoji_test.dart
+++ b/test/verify_emoji_test.dart
@@ -1,5 +1,6 @@
+import 'package:checks/checks.dart';
 import 'package:qr/qr.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('Generate QR with Emoji', () {
@@ -8,8 +9,8 @@ void main() {
       payload: QrPayload.fromString(emojiString),
       errorCorrectLevel: QrErrorCorrectLevel.low,
     );
-    expect(qr.typeNumber, 2);
-    expect(qr.typeNumber, greaterThan(0));
+    check(qr.typeNumber).equals(2);
+    check(qr.typeNumber).isGreaterThan(0);
     // Verify we have multiple segments (ECI + Byte)
     // iterate over modules or check internal structure if possible
     // (but it's private)
@@ -26,7 +27,7 @@ void main() {
       payload: QrPayload.fromString(complexEmoji),
       errorCorrectLevel: QrErrorCorrectLevel.low,
     );
-    expect(qr.typeNumber, greaterThan(0));
+    check(qr.typeNumber).isGreaterThan(0);
     // Verify it didn't throw and created a valid QR structure
     // The exact type number depends on the overhead of ECI + Byte mode
 
@@ -36,6 +37,6 @@ void main() {
 
     // We can't easily peek into _dataList, but we can verify the module count
     // implies it's not empty
-    expect(qr.moduleCount, greaterThan(21));
+    check(qr.moduleCount).isGreaterThan(21);
   });
 }

--- a/test/verify_emoji_test.dart
+++ b/test/verify_emoji_test.dart
@@ -10,7 +10,6 @@ void main() {
       errorCorrectLevel: QrErrorCorrectLevel.low,
     );
     check(qr.typeNumber).equals(2);
-    check(qr.typeNumber).isGreaterThan(0);
     // Verify we have multiple segments (ECI + Byte)
     // iterate over modules or check internal structure if possible
     // (but it's private)

--- a/test/verify_qr_tool_test.dart
+++ b/test/verify_qr_tool_test.dart
@@ -3,8 +3,9 @@ library;
 
 import 'dart:io';
 
+import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 import 'package:test_process/test_process.dart';
 
 void main() {
@@ -52,11 +53,10 @@ void main() {
         final process = await TestProcess.start('dart', args);
         await process.shouldExit(0);
 
-        expect(
+        check(
+          because: 'BMP file should be created',
           File(bmpPath).existsSync(),
-          isTrue,
-          reason: 'BMP file should be created',
-        );
+        ).isTrue();
 
         // Validate with zbarimg
         // zbarimg output format: QR-Code:content
@@ -69,7 +69,7 @@ void main() {
           print('Input: $input');
           print('Output: "$output"');
         }
-        expect(output, 'QR-Code:$input');
+        check(output).equals('QR-Code:$input');
       }, timeout: const Timeout(Duration(seconds: 20)));
     }
   }
@@ -92,11 +92,10 @@ void main() {
 
     final process = await TestProcess.start('dart', args);
     await process.shouldExit(0);
-    expect(
+    check(
+      because: 'BMP file should be created',
       File(bmpPath).existsSync(),
-      isTrue,
-      reason: 'BMP file should be created',
-    );
+    ).isTrue();
 
     final zbar = await TestProcess.start('zbarimg', ['--quiet', bmpPath]);
     await zbar.shouldExit(0);
@@ -107,7 +106,7 @@ void main() {
       print('Input: $input');
       print('Output: "$output"');
     }
-    expect(output, 'QR-Code:$input');
+    check(output).equals('QR-Code:$input');
   });
 
   test('Error case: Missing output argument', () async {
@@ -117,10 +116,9 @@ void main() {
     ]);
     await process.shouldExit(1);
     final output = await process.stdout.next;
-    expect(
+    check(
       output,
-      contains('Error: Invalid argument(s): Option output is mandatory.'),
-    );
+    ).contains('Error: Invalid argument(s): Option output is mandatory.');
   });
 
   test('Error case: Invalid version', () async {


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).