### PR TITLE
style: format markdown files with 80-column line wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,38 @@
 
 ## 4.0.0
 
-- **Breaking Change**: Removed `QrBitBuffer` from public exports to tighten the API surface.
-- **Breaking Change**: `QrErrorCorrectLevel` is now an enum (`low`, `medium`, `quartile`, `high`) instead of a class with integer constants (`L`, `M`, `Q`, `H`).
-- **Breaking Change**: `QrCode` and `QrImage` constructors and properties now use the `QrErrorCorrectLevel` enum instead of integers.
+- **Breaking Change**: Removed `QrBitBuffer` from public exports to tighten the
+  API surface.
+- **Breaking Change**: `QrErrorCorrectLevel` is now an enum (`low`, `medium`,
+  `quartile`, `high`) instead of a class with integer constants (`L`, `M`, `Q`,
+  `H`).
+- **Breaking Change**: `QrCode` and `QrImage` constructors and properties now
+  use the `QrErrorCorrectLevel` enum instead of integers.
 - **Breaking Change**: Removed `dataCache` getter from `QrCode`.
-- **Breaking Change**: `QrCode` is now immutable. Removed `addData`, `addByteData`, `addNumeric`, `addAlphaNumeric`, and `addECI` from `QrCode`.
-- **Breaking Change**: Consolidated `QrCode` constructors into a single public factory constructor taking `QrPayload`, `errorCorrectLevel`, and an optional `minTypeNumber`. Removed `QrCode.fromData`, `QrCode.fromUint8List`, and `QrCode.fromPayload`.
-- **Breaking Change**: Replaced `Uint8List` and `ByteData` in public API signatures with `TypedData`.
-- **Breaking Change**: Marked all public classes (`QrCode`, `QrImage`, `QrPayload`, `QrValidationResult`, `InputTooLongException`) as `final class` to enforce structural immutability and prevent external subtyping.
-- Added `QrPayload` class as a standalone accumulator for multi-part data and encoding modes (Numeric, Alphanumeric, Byte, ECI). Includes constructors `fromString`, `fromTypedData`, and methods `addString`, `addTypedData`, `addNumeric`, `addAlphaNumeric`, `addECI`.
-- Added Extended Channel Interpretation (ECI) support via `QrPayload.addECI` and the `QrEciValue` extension type.
-- Added `QrValidationResult.fromPayload` factory constructor to validate QR code payloads and predict valid configurations.
+- **Breaking Change**: `QrCode` is now immutable. Removed `addData`,
+  `addByteData`, `addNumeric`, `addAlphaNumeric`, and `addECI` from `QrCode`.
+- **Breaking Change**: Consolidated `QrCode` constructors into a single public
+  factory constructor taking `QrPayload`, `errorCorrectLevel`, and an optional
+  `minTypeNumber`. Removed `QrCode.fromData`, `QrCode.fromUint8List`, and
+  `QrCode.fromPayload`.
+- **Breaking Change**: Replaced `Uint8List` and `ByteData` in public API
+  signatures with `TypedData`.
+- **Breaking Change**: Marked all public classes (`QrCode`, `QrImage`,
+  `QrPayload`, `QrValidationResult`, `InputTooLongException`) as `final class`
+  to enforce structural immutability and prevent external subtyping.
+- Added `QrPayload` class as a standalone accumulator for multi-part data and
+  encoding modes (Numeric, Alphanumeric, Byte, ECI). Includes constructors
+  `fromString`, `fromTypedData`, and methods `addString`, `addTypedData`,
+  `addNumeric`, `addAlphaNumeric`, `addECI`.
+- Added Extended Channel Interpretation (ECI) support via `QrPayload.addECI` and
+  the `QrEciValue` extension type.
+- Added `QrValidationResult.fromPayload` factory constructor to validate QR code
+  payloads and predict valid configurations.
 - Added `QrValidationResult` class returned by validation constructor.
-- `QrPayload.fromString` and `QrPayload.addString` now intelligently pick the right mode.
-- Throws `InputTooLongException` for data that exceeds QR code version 40 capacity, preventing the generation of invalid QR codes.
+- `QrPayload.fromString` and `QrPayload.addString` now intelligently pick the
+  right mode.
+- Throws `InputTooLongException` for data that exceeds QR code version 40
+  capacity, preventing the generation of invalid QR codes.
 - Performance improvements for QR code generation.
   - `QrImage` generation is ~50% faster.
   - `LargeQrCode` generation is ~40% faster.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,19 @@
 ## Code Quality
 
-Before submitting a pull request, please ensure your code meets the following standards:
+Before submitting a pull request, please ensure your code meets the following
+standards:
 
 - **Formatting**: Format your code using `dart format .`
 - **Tests**: Ensure all tests pass by running `dart test`
 - **Analysis**: Verify the analyzer is happy by running `dart analyze`
 
-> **Note**: Feel free to use the Dart MCP server to help you with any of the above tasks.
+> **Note**: Feel free to use the Dart MCP server to help you with any of the
+> above tasks.
 
 ## Optional: Running Skipped Tests
 
-If you have [`zbar`](https://zbar.sourceforge.net/) installed, you can run the skipped tests (which use `zbar` for validation) using the following command:
+If you have [`zbar`](https://zbar.sourceforge.net/) installed, you can run the
+skipped tests (which use `zbar` for validation) using the following command:
 
 ```bash
 dart test --run-skipped

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,7 @@
 # Repository Rules for AI Agents
 
 ## Tech Stack
+
 - **Language**: Dart
   - see pubspec.yaml for SDK constraints
 - **Web**: `package:web` (do NOT use `dart:html`)
@@ -19,16 +20,20 @@ Reference `CONTRIBUTING.md` for testing information.
 Reference `CONTRIBUTING.md` for web development information.
 
 ## General
+
 - Keep changes minimal and focused.
 - Follow existing patterns in the codebase.
 - Always check analyzer for lints and fix them.
 
 ### Troubleshooting
-If `dart run build_runner serve` fails with "address in use", you can search for the process using the port (e.g. 8080) using `witr`.
+
+If `dart run build_runner serve` fails with "address in use", you can search for
+the process using the port (e.g. 8080) using `witr`.
 
 ```bash
 witr -o 8080 --json
 ```
 
-If the output indicates that `build_runner` is already serving the current directory, you can reuse that instance.
-Otherwise, you should prompt the user to stop the conflicting process.
+If the output indicates that `build_runner` is already serving the current
+directory, you can reuse that instance. Otherwise, you should prompt the user to
+stop the conflicting process.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ final qrCode = QrCode(
 final qrImage = QrImage(qrCode);
 ```
 
-To enable Extended Channel Interpretation (ECI) mode or build multi-part data, you can use `QrPayload`:
+To enable Extended Channel Interpretation (ECI) mode or build multi-part data,
+you can use `QrPayload`:
 
 ```dart
 final payload = QrPayload()
@@ -64,7 +65,7 @@ See the `example` directory for further details.
 
 # Packages that use `package:qr`
 
-- [pretty_qr_code](https://pub.dev/packages/pretty_qr_code) - A Flutter Widget to render
-QR codes
+- [pretty_qr_code](https://pub.dev/packages/pretty_qr_code) - A Flutter Widget
+  to render QR codes
 - [qr_image_exporter](https://pub.dev/packages/qr_image_exporter) - A library to
-export QR codes as PNG image data.
+  export QR codes as PNG image data.

--- a/lib/src/readme.md
+++ b/lib/src/readme.md
@@ -1,27 +1,26 @@
-# Original License #
+# Original License
 
     QRCode for ActionScript
     version 1.0.1
     Copyright (C) Kazuhiko Arase all rights reserved.
 
-# The MIT License #
+# The MIT License
 
 Copyright (c) 2010-2011 Pixel Lab
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
- Wrap markdown prose within 80 columns using Prettier/mdf.
- Normalize bullet markers and standardize block whitespace.
